### PR TITLE
Replace static AWS credentials with OIDC role assumption

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -4,6 +4,10 @@ on: [push]
 
 env:
   ECR_REPOSITORY: toolbox
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   upload-docker-image:
     runs-on: ubuntu-latest
@@ -14,8 +18,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.TRUSS_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TRUSS_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::127178877223:role/github/github-truss
           aws-region: us-east-2
 
       - name: Login to AWS ECR

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ ENV VAULT_ADDR https://vault.vault.svc:8200
 ENV VAULT_SKIP_VERIFY true
 
 # kubectl
-COPY --from=bitnami/kubectl:1.33.2 /opt/bitnami/kubectl/bin/kubectl /usr/bin/kubectl
+ADD https://dl.k8s.io/release/v1.34.11/bin/linux/amd64/kubectl /usr/bin/kubectl
+RUN chmod +x /usr/bin/kubectl
 
 # AWS CLI
 RUN apk add --no-cache aws-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ ENV VAULT_ADDR https://vault.vault.svc:8200
 ENV VAULT_SKIP_VERIFY true
 
 # kubectl
-ADD https://dl.k8s.io/release/v1.34.11/bin/linux/amd64/kubectl /usr/bin/kubectl
+ADD --checksum=sha256:8efbb9435132a190920eb65a47a8c1ecf755ad85ab57a600c9bedbab460bb7a8 \
+    https://dl.k8s.io/release/v1.34.11/bin/linux/amd64/kubectl /usr/bin/kubectl
 RUN chmod +x /usr/bin/kubectl
 
 # AWS CLI


### PR DESCRIPTION
## Summary

- Replace static IAM credentials (`TRUSS_AWS_ACCESS_KEY_ID` / `TRUSS_AWS_SECRET_ACCESS_KEY`) with OIDC role assumption via `aws-actions/configure-aws-credentials`
- Add `permissions: id-token: write` at the workflow level to enable OIDC token generation
- Part of org-wide OIDC migration ([PIER-821](https://getbridge.atlassian.net/browse/PIER-821))

## Additional fixes (pre-existing issues discovered during CI)

- **Update kubectl from `bitnami/kubectl:1.33.2` to direct download of v1.34.11** — Bitnami purged versioned image tags, breaking the `COPY --from` in the Dockerfile. Now downloads kubectl directly from the official Kubernetes release URL with SHA256 checksum verification. Updated to v1.34.11 to match production.

## Test plan

- [ ] CI checks pass on this PR
- [ ] Verify workflow runs succeed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PIER-821]: https://getbridge.atlassian.net/browse/PIER-821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ